### PR TITLE
Restore default PLN URL

### DIFF
--- a/PLNPlugin.inc.php
+++ b/PLNPlugin.inc.php
@@ -21,8 +21,7 @@ import('classes.issue.Issue');
 define('PLN_PLUGIN_NAME', 'plnplugin');
 
 // defined here in case an upgrade doesn't pick up the default value.
-// define('PLN_DEFAULT_NETWORK', 'http://pkp-pln.lib.sfu.ca');
-define('PLN_DEFAULT_NETWORK', 'http://localhost:8080/symfony/pkppln/web');
+define('PLN_DEFAULT_NETWORK', 'http://pkp-pln.lib.sfu.ca');
 
 define('PLN_DEFAULT_STATUS_SUFFIX', '/docs/status');
 


### PR DESCRIPTION
The PLN URL can be overridden using `config.inc.php`:
```
[lockss]
pln_url = "http://..."
```