### PR TITLE
Remove error-causing import statement

### DIFF
--- a/PLNGatewayPlugin.inc.php
+++ b/PLNGatewayPlugin.inc.php
@@ -21,9 +21,6 @@ import('lib.pkp.classes.core.ArrayItemIterator');
 
 define('PLN_PLUGIN_PING_ARTICLE_COUNT', 12);
 
-// Archive/Tar.php may not be installed, so supress possible error.
-@include_once('Archive/Tar.php');
-
 class PLNGatewayPlugin extends GatewayPlugin {
 	/** @var $parentPluginName string Name of parent plugin */
 	var $parentPluginName;


### PR DESCRIPTION
@defstat, this was necessary on my machine (PHP7.2.0) to avoid a fatal error with no error message. I installed the PEAR Archive/Tar package and that seems to be fine, but I don't think there's any case where an `include_once` like the one this PR removes will be required, is there?