### PR TITLE
Avoid headless use of Request object

### DIFF
--- a/PLNPlugin.inc.php
+++ b/PLNPlugin.inc.php
@@ -537,7 +537,8 @@ class PLNPlugin extends GenericPlugin {
 		$locale = $context->getPrimaryLocale();
 		$language = strtolower(str_replace('_', '-', $locale));
 		$network = $this->getSetting($context->getId(), 'pln_network');
-		$dispatcher = $request->getDispatcher();
+		$application = Application::getApplication();
+		$dispatcher = $application->getDispatcher();
 
 		// retrieve the service document
 		$result = $this->_curlGet(

--- a/classes/DepositPackage.inc.php
+++ b/classes/DepositPackage.inc.php
@@ -143,7 +143,8 @@ class DepositPackage {
 		$entry->appendChild($title);
 
 		$request = PKPApplication::getRequest();
-		$dispatcher = $request->getDispatcher();
+		$application = PKPApplication::getApplication();
+		$dispatcher = $application->getDispatcher();
 
 		$pkpJournalUrl = $this->_generateElement($atom, 'pkp:journal_url', $dispatcher->url($request, ROUTE_PAGE, $journal->getPath()), 'http://pkp.sfu.ca/SWORD');
 		$entry->appendChild($pkpJournalUrl);
@@ -318,7 +319,8 @@ class DepositPackage {
 				break;
 			case PLN_PLUGIN_DEPOSIT_OBJECT_ISSUE:
 				// we only ever do one issue at a time, so get that issue
-				$request = Application::get()->getRequest();
+				$application = Application::getApplication();
+				$request = $application->getRequest();
 				$depositObject = $depositObjects->next();
 				$issue = $issueDao->getByBestId($depositObject->getObjectId(), $journal->getId());
 


### PR DESCRIPTION
Many uses of the `$request` object will cause fatal errors when running in a headless context (i.e. kicked off by a cron job). In several cases the PLN plugin uses `$request->getDispatcher()` to get the dispatcher, which is then used to generate URLs. When run headlessly, `$request->getDispatcher()` will return `null`, leading to fatal errors. Use `$application->getDispatcher()` instead.