### PR TITLE
Fix incorrect constant name

### DIFF
--- a/PLNPlugin.inc.php
+++ b/PLNPlugin.inc.php
@@ -338,7 +338,7 @@ class PLNPlugin extends GenericPlugin {
 				if (in_array($op, array('deposits'))) {
 					define('HANDLER_CLASS', 'PLNHandler');
 					define('PLN_PLUGIN_NAME', $this->getName());
-					AppLocale::requireComponents(LOCALE_COMPONENT_APPLICATION_COMMON);
+					AppLocale::requireComponents(LOCALE_COMPONENT_APP_COMMON);
 					$handlerFile =& $args[2];
 					$handlerFile = $this->getHandlerPath() . '/' . 'PLNHandler.inc.php';
 				}


### PR DESCRIPTION
Resolves a PHP warning:
```
PHP Warning:  Use of undefined constant LOCALE_COMPONENT_APPLICATION_COMMON - assumed 'LOCALE_COMPONENT_APPLICATION_COMMON' (this will throw an Error in a future version of PHP) in /home/asmecher/git/pln/PLNPlugin.inc.php on line 341
```