### PR TITLE
#37 Scheduled tasks not installed (fix for acron plugin)

### DIFF
--- a/PLNPlugin.inc.php
+++ b/PLNPlugin.inc.php
@@ -94,8 +94,8 @@ class PLNPlugin extends GenericPlugin {
 				HookRegistry::register('NotificationManager::getNotificationContents', array($this, 'callbackNotificationContents'));
 				HookRegistry::register('LoadComponentHandler', array($this, 'setupComponentHandlers'));
 
-				HookRegistry::register('AcronPlugin::parseCronTab', array($this, 'callbackParseCronTab'));
 			}
+			HookRegistry::register('AcronPlugin::parseCronTab', array($this, 'callbackParseCronTab'));
 		}
 
 		return $success;


### PR DESCRIPTION
This will cause the Acron plugin's "Reload Scheduled Tasks" tool to work. This is *not* a complete fix for the issue, though!