### PR TITLE
pkp/pkp-lib#7088 Replace BagIt library

### DIFF
--- a/PLNGatewayPlugin.inc.php
+++ b/PLNGatewayPlugin.inc.php
@@ -157,7 +157,6 @@ class PLNGatewayPlugin extends GatewayPlugin {
 			$publications[] = $publication;
 			if (count($publications) == PLN_PLUGIN_PING_ARTICLE_COUNT) break;
 		}
-		$submissions->close();
 		$templateMgr->assign('publications', $publications);
 		$templateMgr->assign('pln_network', $plugin->getSetting($journal->getId(), 'pln_network'));
 

--- a/PLNPlugin.inc.php
+++ b/PLNPlugin.inc.php
@@ -365,12 +365,6 @@ class PLNPlugin extends GenericPlugin {
 
 				return new JSONMessage(true, $form->fetch($request));
 			case 'enable':
-				if(!@include_once('Archive/Tar.php')) {
-					$message = NOTIFICATION_TYPE_ERROR;
-					$messageParams = array('contents' => __('plugins.generic.pln.notifications.archive_tar_missing'));
-					break;
-				}
-
 				if(!$this->zipInstalled()) {
 					$message = NOTIFICATION_TYPE_ERROR;
 					$messageParams = array('contents' => __('plugins.generic.pln.notifications.zip_missing'));

--- a/PLNPlugin.inc.php
+++ b/PLNPlugin.inc.php
@@ -615,10 +615,10 @@ class PLNPlugin extends GenericPlugin {
 		$httpClient = Application::get()->getHttpClient();
 		try {
 			$response = $httpClient->request($method, $url, [
-				'headers' => array_merge($headers, [
+				'headers' => [
 					'Content-Type' => mime_content_type($filename),
 					'Content-Length' => filesize($filename),
-				]),
+				],
 				'body' => fopen($filename, 'r'),
 			]);
 		} catch (GuzzleHttp\Exception\RequestException $e) {

--- a/README
+++ b/README
@@ -72,11 +72,6 @@ Build Instructions
 manually. If you are installing the plugin using the Plugin Gallery, they are
 not necessary.)
 
-The plugin depends on the BagIt component
-(https://packagist.org/packages/scholarslab/bagit) and it incorporates it as a
-Composer (https://getcomposer.org/) module. Please make sure you have Composer
-installed before installing the plugin.
-
 - Clone the repository containing the code.
 - Run OJS's "php tools/upgrade.php upgrade"
 - Execute "composer install" from console, being in the cloned pln folder.

--- a/classes/DepositPackage.inc.php
+++ b/classes/DepositPackage.inc.php
@@ -245,10 +245,7 @@ class DepositPackage {
 	 * @return string The full path of the created zip archive
 	 */
 	public function generatePackage() {
-		if (!@include_once(dirname(__FILE__).'/../vendor/scholarslab/bagit/lib/bagit.php')) {
-			$this->_logMessage(__('plugins.generic.pln.error.include.bagit'));
-			return;
-		}
+		require_once(dirname(__FILE__) . '/../vendor/autoload.php');
 
 		// get DAOs, plugins and settings
 		$journalDao = DAORegistry::getDAO('JournalDAO');
@@ -270,7 +267,12 @@ class DepositPackage {
 		$exportFile = tempnam(sys_get_temp_dir(), 'ojs-pln-export-');
 		$termsFile = tempnam(sys_get_temp_dir(), 'ojs-pln-terms-');
 
-		$bag = new BagIt($bagDir);
+		// Work around https://github.com/whikloj/BagItTools/issues/26:
+		// Determine if the path is relative, and if it is, prefix with ./
+		if (!preg_match('#^[a-zA-Z]:\\\\#', $bagDir) && strpos($bagDir, '/') !== 0) $bagDir = getcwd() . '/' . $bagDir;
+
+		$bag = \whikloj\BagItTools\Bag::create($bagDir);
+
 		$fileList = array();
 		import('lib.pkp.classes.file.FileManager');
 		$fileManager = new FileManager();
@@ -357,6 +359,13 @@ class DepositPackage {
 		// add the exported content to the bag
 		$bag->addFile($exportFile, $this->_deposit->getObjectType() . $this->_deposit->getUUID() . '.xml');
 		foreach ($fileList as $sourcePath => $targetPath) {
+			// $sourcePath is a relative path to the files directory; add the files directory to the front
+			$sourcePath = rtrim(Config::getVar('files', 'files_dir'), '/') . '/' . $sourcePath;
+
+			// Work around https://github.com/whikloj/BagItTools/issues/26:
+			// Determine if the path is relative, and if it is, prefix with ./
+			if (!preg_match('#^[a-zA-Z]:\\\\#', $sourcePath) && strpos($sourcePath, '/') !== 0) $sourcePath = getcwd() . '/' . $sourcePath;
+
 			$bag->addFile($sourcePath, $targetPath);
 		}
 
@@ -385,18 +394,18 @@ class DepositPackage {
 		// Add OJS Version
 		$versionDao = DAORegistry::getDAO('VersionDAO');
 		$currentVersion = $versionDao->getCurrentVersion();
-		$bag->setBagInfoData('PKP-PLN-OJS-Version', $currentVersion->getVersionString());
+		$bag->setExtended(true);
+		$bag->addBagInfoTag('PKP-PLN-OJS-Version', $currentVersion->getVersionString());
 
 		$bag->update();
 
 		// create the bag
-		$bag->package($packageFile, 'zip');
+		$bag->package($packageFile);
 
 		// remove the temporary bag directory and temp files
 		$fileManager->rmtree($bagDir);
 		$fileManager->deleteByPath($exportFile);
 		$fileManager->deleteByPath($termsFile);
-
 		return $packageFile;
 	}
 

--- a/classes/form/PLNSettingsForm.inc.php
+++ b/classes/form/PLNSettingsForm.inc.php
@@ -66,9 +66,6 @@ class PLNSettingsForm extends Form {
 	public function _checkPrerequisites() {
 		$messages = array();
 
-		if (!@include_once('Archive/Tar.php')) {
-			$messages[] = __('plugins.generic.pln.notifications.archive_tar_missing');
-		}
 		if (!$this->_plugin->zipInstalled()) {
 			$messages = __('plugins.generic.pln.notifications.zip_missing');
 		}

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "require": {
-    "scholarslab/bagit": "~0.2"
-  }
+    "require": {
+        "whikloj/bagittools": "^2.1"
+    }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8675cb68f22925a33fe9d3e54d51b318",
+    "content-hash": "86fcdea73764c662bc6603ba55a0e667",
     "packages": [
         {
             "name": "pear/archive_tar",
-            "version": "1.4.7",
+            "version": "1.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pear/Archive_Tar.git",
-                "reference": "7e48add6f8edc3027dd98ad15964b1a28fd0c845"
+                "reference": "2b87b41178cc6d4ad3cba678a46a1cae49786011"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pear/Archive_Tar/zipball/7e48add6f8edc3027dd98ad15964b1a28fd0c845",
-                "reference": "7e48add6f8edc3027dd98ad15964b1a28fd0c845",
+                "url": "https://api.github.com/repos/pear/Archive_Tar/zipball/2b87b41178cc6d4ad3cba678a46a1cae49786011",
+                "reference": "2b87b41178cc6d4ad3cba678a46a1cae49786011",
                 "shasum": ""
             },
             "require": {
@@ -70,20 +70,34 @@
                 "archive",
                 "tar"
             ],
-            "time": "2019-04-08T13:15:55+00:00"
+            "support": {
+                "issues": "http://pear.php.net/bugs/search.php?cmd=display&package_name[]=Archive_Tar",
+                "source": "https://github.com/pear/Archive_Tar"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/mrook",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/michielrook",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2021-02-16T10:50:50+00:00"
         },
         {
             "name": "pear/console_getopt",
-            "version": "v1.4.2",
+            "version": "v1.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pear/Console_Getopt.git",
-                "reference": "6c77aeb625b32bd752e89ee17972d103588b90c0"
+                "reference": "a41f8d3e668987609178c7c4a9fe48fecac53fa0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pear/Console_Getopt/zipball/6c77aeb625b32bd752e89ee17972d103588b90c0",
-                "reference": "6c77aeb625b32bd752e89ee17972d103588b90c0",
+                "url": "https://api.github.com/repos/pear/Console_Getopt/zipball/a41f8d3e668987609178c7c4a9fe48fecac53fa0",
+                "reference": "a41f8d3e668987609178c7c4a9fe48fecac53fa0",
                 "shasum": ""
             },
             "type": "library",
@@ -101,36 +115,40 @@
             ],
             "authors": [
                 {
-                    "name": "Greg Beaver",
-                    "role": "Helper",
-                    "email": "cellog@php.net"
-                },
-                {
                     "name": "Andrei Zmievski",
-                    "role": "Lead",
-                    "email": "andrei@php.net"
+                    "email": "andrei@php.net",
+                    "role": "Lead"
                 },
                 {
                     "name": "Stig Bakken",
-                    "role": "Developer",
-                    "email": "stig@php.net"
+                    "email": "stig@php.net",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Greg Beaver",
+                    "email": "cellog@php.net",
+                    "role": "Helper"
                 }
             ],
             "description": "More info available on: http://pear.php.net/package/Console_Getopt",
-            "time": "2019-02-06T16:52:33+00:00"
+            "support": {
+                "issues": "http://pear.php.net/bugs/search.php?cmd=display&package_name[]=Console_Getopt",
+                "source": "https://github.com/pear/Console_Getopt"
+            },
+            "time": "2019-11-20T18:27:48+00:00"
         },
         {
             "name": "pear/pear-core-minimal",
-            "version": "v1.10.9",
+            "version": "v1.10.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pear/pear-core-minimal.git",
-                "reference": "742be8dd68c746a01e4b0a422258e9c9cae1c37f"
+                "reference": "625a3c429d9b2c1546438679074cac1b089116a7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pear/pear-core-minimal/zipball/742be8dd68c746a01e4b0a422258e9c9cae1c37f",
-                "reference": "742be8dd68c746a01e4b0a422258e9c9cae1c37f",
+                "url": "https://api.github.com/repos/pear/pear-core-minimal/zipball/625a3c429d9b2c1546438679074cac1b089116a7",
+                "reference": "625a3c429d9b2c1546438679074cac1b089116a7",
                 "shasum": ""
             },
             "require": {
@@ -156,32 +174,36 @@
             "authors": [
                 {
                     "name": "Christian Weiske",
-                    "role": "Lead",
-                    "email": "cweiske@php.net"
+                    "email": "cweiske@php.net",
+                    "role": "Lead"
                 }
             ],
             "description": "Minimal set of PEAR core files to be used as composer dependency",
-            "time": "2019-03-13T18:15:44+00:00"
+            "support": {
+                "issues": "http://pear.php.net/bugs/search.php?cmd=display&package_name[]=PEAR",
+                "source": "https://github.com/pear/pear-core-minimal"
+            },
+            "time": "2019-11-19T19:00:24+00:00"
         },
         {
             "name": "pear/pear_exception",
-            "version": "v1.0.0",
+            "version": "v1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pear/PEAR_Exception.git",
-                "reference": "8c18719fdae000b690e3912be401c76e406dd13b"
+                "reference": "b14fbe2ddb0b9f94f5b24cf08783d599f776fff0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pear/PEAR_Exception/zipball/8c18719fdae000b690e3912be401c76e406dd13b",
-                "reference": "8c18719fdae000b690e3912be401c76e406dd13b",
+                "url": "https://api.github.com/repos/pear/PEAR_Exception/zipball/b14fbe2ddb0b9f94f5b24cf08783d599f776fff0",
+                "reference": "b14fbe2ddb0b9f94f5b24cf08783d599f776fff0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=4.4.0"
+                "php": ">=5.2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "*"
+                "phpunit/phpunit": "<9"
             },
             "type": "class",
             "extra": {
@@ -190,9 +212,9 @@
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "PEAR": ""
-                }
+                "classmap": [
+                    "PEAR/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "include-path": [
@@ -216,37 +238,72 @@
             "keywords": [
                 "exception"
             ],
-            "time": "2015-02-10T20:07:52+00:00"
+            "support": {
+                "issues": "http://pear.php.net/bugs/search.php?cmd=display&package_name[]=PEAR_Exception",
+                "source": "https://github.com/pear/PEAR_Exception"
+            },
+            "time": "2021-03-21T15:43:46+00:00"
         },
         {
-            "name": "scholarslab/bagit",
-            "version": "0.3.0",
+            "name": "whikloj/bagittools",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/scholarslab/BagItPHP.git",
-                "reference": "8d197da6d18c06a7aa880d853eb50820f408c4bb"
+                "url": "https://github.com/whikloj/BagItTools.git",
+                "reference": "eb20c3fc8300f9336228ba414da8971b1dfc0ec8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/scholarslab/BagItPHP/zipball/8d197da6d18c06a7aa880d853eb50820f408c4bb",
-                "reference": "8d197da6d18c06a7aa880d853eb50820f408c4bb",
+                "url": "https://api.github.com/repos/whikloj/BagItTools/zipball/eb20c3fc8300f9336228ba414da8971b1dfc0ec8",
+                "reference": "eb20c3fc8300f9336228ba414da8971b1dfc0ec8",
                 "shasum": ""
             },
             "require": {
-                "pear/archive_tar": "~1.3"
+                "ext-curl": "*",
+                "ext-intl": "*",
+                "ext-mbstring": "*",
+                "ext-zip": "*",
+                "pear/archive_tar": "^1.4",
+                "php": ">=7.2"
             },
             "require-dev": {
-                "mayflower/php-codebrowser": "~1.1",
-                "pdepend/pdepend": "2.1.0",
-                "phpdocumentor/phpdocumentor": "2.*",
-                "phpmd/phpmd": "@stable",
-                "phpunit/phpunit": "~4.4",
-                "sebastian/phpcpd": "*",
-                "squizlabs/php_codesniffer": "2.*"
+                "donatj/mock-webserver": "^2.1",
+                "phpdocumentor/phpdocumentor": "^2.0",
+                "phpunit/phpunit": "^7.0",
+                "sebastian/phpcpd": "^4.0",
+                "squizlabs/php_codesniffer": "^3.5"
             },
             "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "whikloj\\BagItTools\\": "src/"
+                }
+            },
             "notification-url": "https://packagist.org/downloads/",
-            "time": "2015-08-25T17:45:02+00:00"
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jared Whiklo",
+                    "email": "jwhiklo@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A PHP library to manipulate and verify BagIt bags.",
+            "homepage": "https://github.com/whikloj/bagittools",
+            "keywords": [
+                "bagit",
+                "bags",
+                "data",
+                "integrity",
+                "transmission"
+            ],
+            "support": {
+                "issues": "https://github.com/whikloj/BagItTools/issues",
+                "source": "https://github.com/whikloj/BagItTools/tree/2.1.0"
+            },
+            "time": "2020-11-09T14:24:47+00:00"
         }
     ],
     "packages-dev": [],
@@ -256,5 +313,6 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.0.0"
 }

--- a/exclusions.txt
+++ b/exclusions.txt
@@ -1,4 +1,6 @@
-pln/vendor/scholarslab/bagit/test
+pln/vendor/whikloj/bagittools/tests
+pln/vendor/whikloj/bagittools/.gitignore
+pln/vendor/whikloj/bagittools/.travis.yml
 pln/vendor/pear/archive_tar/tests
 pln/vendor/pear/archive_tar/.gitignore
 pln/vendor/pear/archive_tar/.travis.yml
@@ -9,7 +11,5 @@ pln/vendor/pear/console_getopt/tests
 pln/vendor/pear/console_getopt/.gitignore
 pln/vendor/pear/console_getopt/.travis.yml
 pln/vendor/scholarslab/bagit/.gitignore
-pln/vendor/scholarslab/bagit/.travis.yml
-pln/vendor/scholarslab/bagit/bin
 pln/.gitattributes
 pln/.gitignore

--- a/locale/ar_IQ/locale.po
+++ b/locale/ar_IQ/locale.po
@@ -191,9 +191,6 @@ msgstr "ينبغي أن يكون لمجلتك رمز ISSN قبل أن يتسنى
 msgid "plugins.generic.pln.notifications.tar_missing"
 msgstr "ينبغي أن تكون لنظامك القدرة على تشغيل ملفات مضغوطة بصيغة tar."
 
-msgid "plugins.generic.pln.notifications.archive_tar_missing"
-msgstr "ينبغي تنصيب إضافة ضغط الملفات بصيغة Tar والخاصة ببيئة PHP قبل أن يتسنى تمكين وظيفة PKP PN الخاصة بمشروع المعرفة العامة."
-
 msgid "plugins.generic.pln.error.network.servicedocument"
 msgstr "خطأ في الشبكة: {$error} عند الاتصال بـ PKP PN للحصول على مستند الخدمة."
 

--- a/locale/de_DE/locale.po
+++ b/locale/de_DE/locale.po
@@ -182,12 +182,6 @@ msgstr "Ihre Zeitschrift muss über eine ISSN verfügen, bevor Sie den Nutzungsb
 msgid "plugins.generic.pln.notifications.tar_missing"
 msgstr "Ihr System muss über ein tar-Programm verfügen."
 
-msgid "plugins.generic.pln.notifications.archive_tar_missing"
-msgstr "Die Archive_Tar-PHP-Erweiterung muss installiert werden, bevor das PKP PN aktiviert werden kann."
-
-msgid "plugins.generic.pln.error.include.bagit"
-msgstr "Die in OJS enthaltene BagIt-Bibliothek kann nicht geladen werden, vermutlich aufgrund nicht erfüllter Grundvoraussetzungen."
-
 msgid "plugins.generic.pln.error.network.servicedocument"
 msgstr "Netzwerk-Fehler {$error} beim Versuch, das Service-Dokument vom PKP PN zu holen."
 

--- a/locale/en_US/locale.po
+++ b/locale/en_US/locale.po
@@ -179,12 +179,6 @@ msgstr "Your journal must have an ISSN before you can agree to the terms of serv
 msgid "plugins.generic.pln.notifications.tar_missing"
 msgstr "Your system must have a tar executable."
 
-msgid "plugins.generic.pln.notifications.archive_tar_missing"
-msgstr "The Archive_Tar PHP extension must be installed before the PKP PN can be enabled."
-
-msgid "plugins.generic.pln.error.include.bagit"
-msgstr "The BagIt library, which is included with OJS, cannot be loaded, probably due to a missing prerequisite."
-
 msgid "plugins.generic.pln.error.network.servicedocument"
 msgstr "Network error {$error} connecting to the PKP PN to get the service document."
 

--- a/locale/fr_CA/locale.po
+++ b/locale/fr_CA/locale.po
@@ -194,12 +194,6 @@ msgstr "Votre revue doit avoir un ISSN pour pouvoir accepter les conditions d'ut
 msgid "plugins.generic.pln.notifications.tar_missing"
 msgstr "Votre système doit avoir un exécutable tar."
 
-msgid "plugins.generic.pln.notifications.archive_tar_missing"
-msgstr "L'extension Archive_Tar PHP doit être installée pour pouvoir activer le PKP PLN."
-
-msgid "plugins.generic.pln.error.include.bagit"
-msgstr "La bibliothèque BagIt, qui est comprise dans OJS, ne peut pas être lancée, probablement en raison d'un prérequis manquant."
-
 msgid "plugins.generic.pln.error.network.servicedocument"
 msgstr "Erreur réseau {$error} connexion au PKP PN pour obtenir le document de service."
 

--- a/locale/it_IT/locale.po
+++ b/locale/it_IT/locale.po
@@ -182,12 +182,6 @@ msgstr "La tua rivista deve avere un ISSN definito, prima di accettare le condiz
 msgid "plugins.generic.pln.notifications.tar_missing"
 msgstr "Il sistema deve avere un eseguibile tar."
 
-msgid "plugins.generic.pln.notifications.archive_tar_missing"
-msgstr "Devi installare l'estensione Archive_Tar PHP per poter abilitare la PKP PLN."
-
-msgid "plugins.generic.pln.error.include.bagit"
-msgstr "La libreria BagIt, già compresa in OJS, non può essere caricata, probabilmente a causa di qualche requisito mancante."
-
 msgid "plugins.generic.pln.error.network.servicedocument"
 msgstr "Errore di rete {$error} connettendosi alla PKP PN per ricevere il service document."
 

--- a/locale/pt_BR/locale.po
+++ b/locale/pt_BR/locale.po
@@ -182,12 +182,6 @@ msgstr "A revista deve possuir um ISSN antes de concordar com os termos de servi
 msgid "plugins.generic.pln.notifications.tar_missing"
 msgstr "Um executável tar deve estar disponível."
 
-msgid "plugins.generic.pln.notifications.archive_tar_missing"
-msgstr "A extensão Archive_Tar do PHP deve estar instalada antes de habilitar o plugin PKP PN do PKP."
-
-msgid "plugins.generic.pln.error.include.bagit"
-msgstr "A biblioteca BagIt, incluída com o OJS, não pode ser carregada, provavelmente devido à falta de algum pré-requisito."
-
 msgid "plugins.generic.pln.error.network.servicedocument"
 msgstr "Erro de rede {$error} ao conectar à PKP PN para recuperar documento de serviço."
 

--- a/locale/ru_RU/locale.po
+++ b/locale/ru_RU/locale.po
@@ -182,12 +182,6 @@ msgstr "У вашего журнала должен быть ISSN до того,
 msgid "plugins.generic.pln.notifications.tar_missing"
 msgstr "В вашей системе должен быть исполняемый файл tar."
 
-msgid "plugins.generic.pln.notifications.archive_tar_missing"
-msgstr "Расширение PHP Archive_Tar должно быть установлено до включения PKP PLN."
-
-msgid "plugins.generic.pln.error.include.bagit"
-msgstr "Библиотеку BagIt, входящую в состав OJS, не удается загрузить, скорее всего из-за отсутствия необходимых для ее работы компонент."
-
 msgid "plugins.generic.pln.error.network.servicedocument"
 msgstr "Ошибка сети {$error} при подключении к PKP PN для получения служебного документа."
 

--- a/locale/tr_TR/locale.po
+++ b/locale/tr_TR/locale.po
@@ -215,12 +215,6 @@ msgstr "The PKP PN terms of use have been updated. Agreement with new terms is r
 msgid "plugins.generic.pln.notifications.zip_missing"
 msgstr "ZipArchive support must be enabled to proceed."
 
-msgid "plugins.generic.pln.notifications.archive_tar_missing"
-msgstr "The Archive_Tar PHP extension must be installed before the PKP PN can be enabled."
-
-msgid "plugins.generic.pln.error.include.bagit"
-msgstr "The BagIt library, which is included with OJS, cannot be loaded, probably due to a missing prerequisite."
-
 msgid "plugins.generic.pln.error.network.servicedocument"
 msgstr "Network error {$error} connecting to the PKP PN to get the service document."
 


### PR DESCRIPTION
- Fix a non-breaking warning (https://github.com/defstat/pln/commit/351e8dc2153f6d659611323578e1b967add9db38)
- Replace `scholarslab/bagit` dependency (abandoned) with `whikloj/bagittools`

NEEDS TESTING/FIXING: I currently get a status error when attempting to deposit a package.
```
Network error Client error: `POST http://pkp-pln.lib.sfu.ca/api/sword/2.0/col-iri/[...]` resulted in a `400 Bad Request` response: <?xml version="1.0" encoding="utf-8"?> <sword:error xmlns="http://www.w3.org/2005/Atom" xmlns:sword="http://purl. (truncated...) connecting to the PKP PN to send the deposit. 